### PR TITLE
juplot: avoid failure if /dev/shm not present

### DIFF
--- a/src/juplot.ml
+++ b/src/juplot.ml
@@ -1,4 +1,8 @@
-let tmp_root = if Sys.is_directory "/dev/shm" then "/dev/shm" else "/tmp"
+let tmp_root =
+  match Unix.stat "/dev/shm" with
+  | {st_kind = S_DIR; _} -> "/dev/shm"
+  | _ -> "/tmp"
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> "/tmp"
 
 let draw ?prms ?display_id ?(fmt = `svg) ?size fig =
   let file = Printf.sprintf "%s/juplot" tmp_root in


### PR DESCRIPTION
The `Sys.is_directory fpath` call fails with
```
Fatal error: exception Sys_error("fpath: No such file or directory")
```
when the file is not present. The suggested solution
prevents this issue.

A better solution would also check if the folders are writable,
and if not create a different local temp dir on the fly, but
I think it is overkill in this case.

(see also https://github.com/hennequin-lab/gp/pull/2)

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>